### PR TITLE
add usb gamepad to gameboy emulator

### DIFF
--- a/MCUME_pico2/display/emuapi.cpp
+++ b/MCUME_pico2/display/emuapi.cpp
@@ -1282,14 +1282,12 @@ void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_re
         gamepad_addr = dev_addr;
         gamepad_instance = instance;
         tuh_hid_receive_report(dev_addr, instance);
-        return true;
     }
     
     // Check for keyboard (existing code will handle this)
     uint8_t const itf_protocol = tuh_hid_interface_protocol(dev_addr, instance);
     if (itf_protocol == HID_ITF_PROTOCOL_KEYBOARD) {
         printf("USB keyboard detected\r\n");
-        return true;
     }
     
     // Check for generic gamepad/joystick
@@ -1309,11 +1307,9 @@ void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_re
         gamepad_addr = dev_addr;
         gamepad_instance = instance;
         tuh_hid_receive_report(dev_addr, instance);
-        return true;
     }
     
     // Not a supported device
-    return false;
 }
 
 // Invoked when device with hid interface is unmounted

--- a/MCUME_pico2/display/emuapi.cpp
+++ b/MCUME_pico2/display/emuapi.cpp
@@ -1269,7 +1269,7 @@ static void process_gamepad_report(uint8_t const* report, uint16_t len) {
 // TinyUSB callbacks for HID devices
 
 // Invoked when device with hid interface is mounted
-bool tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len) {
+void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len) {
     uint16_t vid, pid;
     tuh_vid_pid_get(dev_addr, &vid, &pid);
     

--- a/MCUME_pico2/display/emuapi.cpp
+++ b/MCUME_pico2/display/emuapi.cpp
@@ -1223,6 +1223,9 @@ static void signal_joy (int code, int pressed, int flags) {
   if ( (code == ' ') && (!pressed) ) usbnavpad &= ~MASK_KEY_USER4;
 }
 
+void kbd_signal_raw_key (int keycode, int code, int codeshifted, int flags, int pressed) {
+  //printf("k %d\r\n", keycode); 
+
 static void process_gamepad_report(uint8_t const* report, uint16_t len) {
     // Check if we have enough data
     if (len < 9) return;
@@ -1339,9 +1342,8 @@ void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t cons
     // Request to receive report again
     tuh_hid_receive_report(dev_addr, instance);
 }
+#endif
 
-void kbd_signal_raw_key (int keycode, int code, int codeshifted, int flags, int pressed) {
-  //printf("k %d\r\n", keycode); 
 #ifdef FILEBROWSER
   if (menuActive())
   {

--- a/MCUME_pico2/display/emuapi.cpp
+++ b/MCUME_pico2/display/emuapi.cpp
@@ -1282,12 +1282,14 @@ void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_re
         gamepad_addr = dev_addr;
         gamepad_instance = instance;
         tuh_hid_receive_report(dev_addr, instance);
+        return true;
     }
     
     // Check for keyboard (existing code will handle this)
     uint8_t const itf_protocol = tuh_hid_interface_protocol(dev_addr, instance);
     if (itf_protocol == HID_ITF_PROTOCOL_KEYBOARD) {
         printf("USB keyboard detected\r\n");
+        return true;
     }
     
     // Check for generic gamepad/joystick
@@ -1307,9 +1309,11 @@ void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_re
         gamepad_addr = dev_addr;
         gamepad_instance = instance;
         tuh_hid_receive_report(dev_addr, instance);
+        return true;
     }
     
     // Not a supported device
+    return false;
 }
 
 // Invoked when device with hid interface is unmounted

--- a/MCUME_pico2/display/emuapi.cpp
+++ b/MCUME_pico2/display/emuapi.cpp
@@ -1223,9 +1223,6 @@ static void signal_joy (int code, int pressed, int flags) {
   if ( (code == ' ') && (!pressed) ) usbnavpad &= ~MASK_KEY_USER4;
 }
 
-void kbd_signal_raw_key (int keycode, int code, int codeshifted, int flags, int pressed) {
-  //printf("k %d\r\n", keycode); 
-
 static void process_gamepad_report(uint8_t const* report, uint16_t len) {
     // Check if we have enough data
     if (len < 9) return;
@@ -1342,8 +1339,9 @@ void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t cons
     // Request to receive report again
     tuh_hid_receive_report(dev_addr, instance);
 }
-#endif
 
+void kbd_signal_raw_key (int keycode, int code, int codeshifted, int flags, int pressed) {
+  //printf("k %d\r\n", keycode); 
 #ifdef FILEBROWSER
   if (menuActive())
   {

--- a/MCUME_pico2/display/emuapi.cpp
+++ b/MCUME_pico2/display/emuapi.cpp
@@ -1183,6 +1183,10 @@ char * menuSelection(void)
 ********************************/ 
 #ifdef HAS_USBHOST
 
+static bool gamepad_connected = false;
+static uint8_t gamepad_addr = 0;
+static uint8_t gamepad_instance = 0;
+
 #ifdef KEYBOARD_ACTIVATED
 static bool kbdasjoy = false;
 #else
@@ -1221,6 +1225,125 @@ static void signal_joy (int code, int pressed, int flags) {
 
 void kbd_signal_raw_key (int keycode, int code, int codeshifted, int flags, int pressed) {
   //printf("k %d\r\n", keycode); 
+
+static void process_gamepad_report(uint8_t const* report, uint16_t len) {
+    // Check if we have enough data
+    if (len < 9) return;
+    
+    // Clear previous gamepad state while preserving keyboard input
+    uint16_t kbd_state = usbnavpad & (MASK_OSKB);
+    usbnavpad = kbd_state;
+    
+    // D-pad emulation from left analog stick (bytes 1 & 2)
+    // X-axis: 0x00=left, 0x7F=center, 0xFF=right
+    // Y-axis: 0x00=up, 0x7F=center, 0xFF=down
+    uint8_t x_axis = report[1];
+    uint8_t y_axis = report[2];
+    
+    // Apply some deadzone (values near center should be ignored)
+    // Horizontal movement
+    if (x_axis < 0x40) {
+        usbnavpad |= MASK_JOY2_LEFT;
+    } else if (x_axis > 0xB0) {
+        usbnavpad |= MASK_JOY2_RIGHT;
+    }
+    
+    // Vertical movement
+    if (y_axis < 0x40) {
+        usbnavpad |= MASK_JOY2_UP;
+    } else if (y_axis > 0xB0) {
+        usbnavpad |= MASK_JOY2_DOWN;
+    }
+    
+    // Face buttons (byte 6)
+    uint8_t face_buttons = report[6] & 0xF0; // Mask out the base value (0x0F)
+    if (face_buttons & 0x20) usbnavpad |= MASK_JOY2_BTN;  // A button
+    if (face_buttons & 0x40) usbnavpad |= MASK_KEY_USER1; // B button
+    if (face_buttons & 0x10) usbnavpad |= MASK_KEY_USER2; // X button
+    if (face_buttons & 0x80) usbnavpad |= MASK_KEY_USER3; // Y button
+    
+    // Shoulder and menu buttons (byte 7)
+    if (report[7] & 0x01) usbnavpad |= MASK_JOY1_BTN;    // L button
+    if (report[7] & 0x02) usbnavpad |= MASK_KEY_USER4;   // R button
+    if (report[7] & 0x10) usbnavpad |= MASK_KEY_USER2;   // Select (alt mapping)
+    if (report[7] & 0x20) usbnavpad |= MASK_KEY_USER1;   // Start (alt mapping)
+}
+
+// TinyUSB callbacks for HID devices
+
+// Invoked when device with hid interface is mounted
+bool tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len) {
+    uint16_t vid, pid;
+    tuh_vid_pid_get(dev_addr, &vid, &pid);
+    
+    printf("HID device: VID = 0x%04x, PID = 0x%04x\r\n", vid, pid);
+    
+    // Check if this is our known gamepad (Totsu Engineering, 0x081F/0xE401)
+    if (vid == 0x081F && pid == 0xE401) {
+        printf("USB gamepad detected\r\n");
+        gamepad_connected = true;
+        gamepad_addr = dev_addr;
+        gamepad_instance = instance;
+        tuh_hid_receive_report(dev_addr, instance);
+        return true;
+    }
+    
+    // Check for keyboard (existing code will handle this)
+    uint8_t const itf_protocol = tuh_hid_interface_protocol(dev_addr, instance);
+    if (itf_protocol == HID_ITF_PROTOCOL_KEYBOARD) {
+        printf("USB keyboard detected\r\n");
+        return true;
+    }
+    
+    // Check for generic gamepad/joystick
+    bool is_joystick = false;
+    for (uint16_t i = 0; i < desc_len - 2; i++) {
+        // Look for Generic Desktop usage page (0x01) followed by Joystick usage (0x04)
+        if (desc_report[i] == 0x05 && desc_report[i+1] == 0x01 && 
+            i+3 < desc_len && desc_report[i+2] == 0x09 && desc_report[i+3] == 0x04) {
+            is_joystick = true;
+            break;
+        }
+    }
+    
+    if (is_joystick) {
+        printf("Generic USB joystick/gamepad detected\r\n");
+        gamepad_connected = true;
+        gamepad_addr = dev_addr;
+        gamepad_instance = instance;
+        tuh_hid_receive_report(dev_addr, instance);
+        return true;
+    }
+    
+    // Not a supported device
+    return false;
+}
+
+// Invoked when device with hid interface is unmounted
+void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance) {
+    if (dev_addr == gamepad_addr && instance == gamepad_instance) {
+        printf("Gamepad disconnected\r\n");
+        gamepad_connected = false;
+        gamepad_addr = 0;
+        gamepad_instance = 0;
+        
+        // Clear gamepad input flags
+        usbnavpad &= MASK_OSKB;  // Keep only the on-screen keyboard state
+    }
+}
+
+// Invoked when received report from device
+void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* report, uint16_t len) {
+    if (dev_addr == gamepad_addr && instance == gamepad_instance) {
+        // Process gamepad report
+        process_gamepad_report(report, len);
+    }
+    
+    // Request to receive report again
+    tuh_hid_receive_report(dev_addr, instance);
+}
+#endif
+
 #ifdef FILEBROWSER
   if (menuActive())
   {

--- a/MCUME_pico2/display/emuapi.cpp
+++ b/MCUME_pico2/display/emuapi.cpp
@@ -1269,7 +1269,7 @@ static void process_gamepad_report(uint8_t const* report, uint16_t len) {
 // TinyUSB callbacks for HID devices
 
 // Invoked when device with hid interface is mounted
-void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len) {
+bool tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len) {
     uint16_t vid, pid;
     tuh_vid_pid_get(dev_addr, &vid, &pid);
     

--- a/MCUME_pico2/usb_kbd/hid_app.c
+++ b/MCUME_pico2/usb_kbd/hid_app.c
@@ -379,29 +379,29 @@ static void process_gamepad_report(const uint8_t *report) {
 
     // Directional Controls
     // Left is when byte 2 is close to 0x00
-    if (report[1] < 0x40) { 
+    if (report[0] < 0x40) { 
         decoded_report |= MASK_JOY2_RIGHT;  // Note: swapped due to gameboy mapping
     }
     // Right is when byte 2 is close to 0xFF
-    if (report[1] > 0xB0) { 
+    if (report[0] > 0xB0) { 
         decoded_report |= MASK_JOY2_LEFT;   // Note: swapped due to gameboy mapping
     }
     // Up is when byte 1 is close to 0x00
-    if (report[2] < 0x40) { 
+    if (report[1] < 0x40) { 
         decoded_report |= MASK_JOY2_UP; 
     }
     // Down is when byte 1 is close to 0xFF
-    if (report[2] > 0xB0) { 
+    if (report[1] > 0xB0) { 
         decoded_report |= MASK_JOY2_DOWN; 
     }
 
     // A Button (check for 0x2F or 0x1F in byte 6)
-    if ((report[6] & 0x2F) || (report[6] & 0x1F)) { 
+    if ((report[5] & 0x2F) || (report[5] & 0x1F)) { 
         decoded_report |= MASK_KEY_USER3; 
     }
 
     // B Button (check for 0x4F or 0x8F in byte 6)
-    if ((report[6] & 0x4F) || (report[6] & 0x8F)) { 
+    if ((report[5] & 0x4F) || (report[5] & 0x8F)) { 
         decoded_report |= MASK_JOY2_BTN; 
     }
 

--- a/MCUME_pico2/usb_kbd/hid_app.c
+++ b/MCUME_pico2/usb_kbd/hid_app.c
@@ -373,60 +373,48 @@ static void process_kbd_report (hid_keyboard_report_t const *report)
   } 
   prev_report = *report;
 }
- 
+
 static void process_gamepad_report(const uint8_t *report) {
     uint16_t decoded_report = 0;
-    
-    // Fix the directional controls with proper mapping
-    // LEFT on controller maps to RIGHT on GB
-    if (report[2] < 0x40) {
-        decoded_report |= MASK_JOY2_RIGHT;  // Changed from LEFT to RIGHT
+
+    // Directional Controls
+    // Left is when byte 2 is close to 0x00
+    if (report[2] < 0x40) { 
+        decoded_report |= MASK_JOY2_RIGHT;  // Note: swapped due to gameboy mapping
     }
-    
-    // RIGHT on controller maps to LEFT on GB
-    if (report[2] > 0xB0) {
-        decoded_report |= MASK_JOY2_LEFT;  // Changed from RIGHT to LEFT
+    // Right is when byte 2 is close to 0xFF
+    if (report[2] > 0xB0) { 
+        decoded_report |= MASK_JOY2_LEFT;   // Note: swapped due to gameboy mapping
     }
-    
-    // UP and DOWN seem correctly mapped
-    if (report[1] < 0x40) {
-        decoded_report |= MASK_JOY2_UP;
+    // Up is when byte 1 is close to 0x00
+    if (report[1] < 0x40) { 
+        decoded_report |= MASK_JOY2_UP; 
     }
-    
-    if (report[1] > 0xB0) {
-        decoded_report |= MASK_JOY2_DOWN;
+    // Down is when byte 1 is close to 0xFF
+    if (report[1] > 0xB0) { 
+        decoded_report |= MASK_JOY2_DOWN; 
     }
-    
-    // SNES A button (report[6] & 0x20) maps to GB A 
-    if (report[6] & 0x20) {
-        decoded_report |= MASK_KEY_USER3;  // GB A button
+
+    // A Button (check for 0x2F or 0x1F in byte 6)
+    if ((report[6] & 0x20) || (report[6] & 0x10)) { 
+        decoded_report |= MASK_KEY_USER3; 
     }
-    
-    // SNES B button (report[6] & 0x40) maps to GB B
-    if (report[6] & 0x40) {
-        decoded_report |= MASK_JOY2_BTN;  // GB B button
+
+    // B Button (check for 0x4F or 0x8F in byte 6)
+    if ((report[6] & 0x40) || (report[6] & 0x80)) { 
+        decoded_report |= MASK_JOY2_BTN; 
     }
-    
-    // SNES X button could map to another function if needed
-    // if (report[6] & 0x10) {
-    //     decoded_report |= ...;
-    // }
-    
-    // SNES Y button could map to another function if needed
-    // if (report[6] & 0x80) {
-    //     decoded_report |= ...;
-    // }
-    
-    // Select button
-    if (report[7] & 0x10) {
-        decoded_report |= MASK_KEY_USER1;  // GB SELECT
+
+    // Select Button (byte 7, bit 0x10)
+    if (report[7] & 0x10) { 
+        decoded_report |= MASK_KEY_USER1; 
     }
-    
-    // Start button
-    if (report[7] & 0x20) {
-        decoded_report |= MASK_KEY_USER2;  // GB START
+
+    // Start Button (byte 7, bit 0x20)
+    if (report[7] & 0x20) { 
+        decoded_report |= MASK_KEY_USER2; 
     }
-    
+
     // Send the decoded gamepad state
     kbd_signal_raw_gamepad(decoded_report);
 }

--- a/MCUME_pico2/usb_kbd/hid_app.c
+++ b/MCUME_pico2/usb_kbd/hid_app.c
@@ -396,22 +396,22 @@ static void process_gamepad_report(const uint8_t *report) {
     }
 
     // A Button (check for 0x2F or 0x1F in byte 6)
-    if ((report[5] & 0x2F) || (report[5] & 0x1F)) { 
+    if ((report[5] & 0x20) || (report[5] & 0x10)) { 
         decoded_report |= MASK_KEY_USER3; 
     }
 
     // B Button (check for 0x4F or 0x8F in byte 6)
-    if ((report[5] & 0x4F) || (report[5] & 0x8F)) { 
+    if ((report[5] & 0x40) || (report[5] & 0x80)) { 
         decoded_report |= MASK_JOY2_BTN; 
     }
 
     // Select Button (byte 7, bit 0x10)
-    if (report[7] & 0x10) { 
+    if (report[6] & 0x10) { 
         decoded_report |= MASK_KEY_USER1; 
     }
 
     // Start Button (byte 7, bit 0x20)
-    if (report[7] & 0x20) { 
+    if (report[6] & 0x20) { 
         decoded_report |= MASK_KEY_USER2; 
     }
 

--- a/MCUME_pico2/usb_kbd/hid_app.c
+++ b/MCUME_pico2/usb_kbd/hid_app.c
@@ -374,63 +374,57 @@ static void process_kbd_report (hid_keyboard_report_t const *report)
   prev_report = *report;
 }
  
-// this mapping is hard coded for a certain snes-style gamepad and picogb!
 static void process_gamepad_report(const uint8_t *report) {
-    // Create a fresh report state
     uint16_t decoded_report = 0;
     
-    // Print the first few bytes of the report for debugging
-    // printf("GP: %02x %02x %02x %02x %02x %02x %02x %02x\n", 
-    //      report[0], report[1], report[2], report[3], report[4], report[5], report[6], report[7]);
-    
-    // Try a completely different approach to mapping the directional controls
-    
-    // LEFT button -> maps to MASK_JOY2_LEFT
+    // Fix the directional controls with proper mapping
+    // LEFT on controller maps to RIGHT on GB
     if (report[2] < 0x40) {
-        decoded_report |= MASK_JOY2_LEFT;
+        decoded_report |= MASK_JOY2_RIGHT;  // Changed from LEFT to RIGHT
     }
     
-    // RIGHT button -> maps to MASK_JOY2_RIGHT
+    // RIGHT on controller maps to LEFT on GB
     if (report[2] > 0xB0) {
-        decoded_report |= MASK_JOY2_RIGHT;
+        decoded_report |= MASK_JOY2_LEFT;  // Changed from RIGHT to LEFT
     }
     
-    // UP button -> maps to MASK_JOY2_UP
+    // UP and DOWN seem correctly mapped
     if (report[1] < 0x40) {
         decoded_report |= MASK_JOY2_UP;
     }
     
-    // DOWN button -> maps to MASK_JOY2_DOWN
     if (report[1] > 0xB0) {
         decoded_report |= MASK_JOY2_DOWN;
     }
     
-    // A button -> maps to MASK_KEY_USER3 (byte 6, bit 0x20)
-    if ((report[6] & 0x20) || (report[6] & 0x10) || (report[7] & 0x01)) {
-        decoded_report |= MASK_KEY_USER3;
+    // SNES A button (report[6] & 0x20) maps to GB A 
+    if (report[6] & 0x20) {
+        decoded_report |= MASK_KEY_USER3;  // GB A button
     }
     
-    // B button -> maps to MASK_JOY2_BTN (byte 6, bit 0x40)
-    if ((report[6] & 0x40) || (report[6] & 0x80) || (report[7] & 0x02)) {
-        decoded_report |= MASK_JOY2_BTN;
+    // SNES B button (report[6] & 0x40) maps to GB B
+    if (report[6] & 0x40) {
+        decoded_report |= MASK_JOY2_BTN;  // GB B button
     }
     
-    // Select button -> maps to MASK_KEY_USER1 (byte 7, bit 0x10)
+    // SNES X button could map to another function if needed
+    // if (report[6] & 0x10) {
+    //     decoded_report |= ...;
+    // }
+    
+    // SNES Y button could map to another function if needed
+    // if (report[6] & 0x80) {
+    //     decoded_report |= ...;
+    // }
+    
+    // Select button
     if (report[7] & 0x10) {
-        decoded_report |= MASK_KEY_USER1;
+        decoded_report |= MASK_KEY_USER1;  // GB SELECT
     }
     
-    // Start button -> maps to MASK_KEY_USER2 (byte 7, bit 0x20)
+    // Start button
     if (report[7] & 0x20) {
-        decoded_report |= MASK_KEY_USER2;
-    }
-
-    if ((report[6] & 0x20) || (report[6] & 0x10)) {  // A or X button
-        decoded_report |= MASK_KEY_USER1;  // SELECT for boot screen
-    }
-    
-    if ((report[6] & 0x40) || (report[6] & 0x80)) {  // B or Y button
-        decoded_report |= MASK_KEY_USER2;  // START for boot screen
+        decoded_report |= MASK_KEY_USER2;  // GB START
     }
     
     // Send the decoded gamepad state

--- a/MCUME_pico2/usb_kbd/hid_app.c
+++ b/MCUME_pico2/usb_kbd/hid_app.c
@@ -379,29 +379,29 @@ static void process_gamepad_report(const uint8_t *report) {
 
     // Directional Controls
     // Left is when byte 2 is close to 0x00
-    if (report[2] < 0x40) { 
+    if (report[1] < 0x40) { 
         decoded_report |= MASK_JOY2_RIGHT;  // Note: swapped due to gameboy mapping
     }
     // Right is when byte 2 is close to 0xFF
-    if (report[2] > 0xB0) { 
+    if (report[1] > 0xB0) { 
         decoded_report |= MASK_JOY2_LEFT;   // Note: swapped due to gameboy mapping
     }
     // Up is when byte 1 is close to 0x00
-    if (report[1] < 0x40) { 
+    if (report[2] < 0x40) { 
         decoded_report |= MASK_JOY2_UP; 
     }
     // Down is when byte 1 is close to 0xFF
-    if (report[1] > 0xB0) { 
+    if (report[2] > 0xB0) { 
         decoded_report |= MASK_JOY2_DOWN; 
     }
 
     // A Button (check for 0x2F or 0x1F in byte 6)
-    if ((report[6] & 0x20) || (report[6] & 0x10)) { 
+    if ((report[6] & 0x2F) || (report[6] & 0x1F)) { 
         decoded_report |= MASK_KEY_USER3; 
     }
 
     // B Button (check for 0x4F or 0x8F in byte 6)
-    if ((report[6] & 0x40) || (report[6] & 0x80)) { 
+    if ((report[6] & 0x4F) || (report[6] & 0x8F)) { 
         decoded_report |= MASK_JOY2_BTN; 
     }
 
@@ -481,7 +481,7 @@ int proto = tuh_hid_interface_protocol (dev_addr, instance);
       process_kbd_report ((hid_keyboard_report_t const*) report);
       break;
     case HID_ITF_PROTOCOL_NONE:
-		if (len >= 8 && len <= 9) {
+		if (len >= 8) {
 			process_gamepad_report(report);
 		}
 		break;

--- a/MCUME_pico2/usb_kbd/hid_app.c
+++ b/MCUME_pico2/usb_kbd/hid_app.c
@@ -375,45 +375,64 @@ static void process_kbd_report (hid_keyboard_report_t const *report)
 }
 
 static void process_gamepad_report(const uint8_t *report) {
+    // Print the first few bytes of the report for debugging
+    printf("GP: %02x %02x %02x %02x %02x %02x %02x %02x\n", 
+           report[0], report[1], report[2], report[3], 
+           report[4], report[5], report[6], report[7]);
+
     uint16_t decoded_report = 0;
 
     // Directional Controls
-    // Left is when byte 2 is close to 0x00
-    if (report[2] < 0x40) { 
-        decoded_report |= MASK_JOY2_RIGHT;  // Note: swapped due to gameboy mapping
+    // Check both bytes 1 and 2 for each direction
+    // LEFT: byte 2 is 0x00 and byte 1 is 0x7F
+    if (report[2] == 0x00 && report[1] == 0x7F) { 
+        decoded_report |= MASK_JOY2_LEFT; 
     }
-    // Right is when byte 2 is close to 0xFF
-    if (report[2] > 0xB0) { 
-        decoded_report |= MASK_JOY2_LEFT;   // Note: swapped due to gameboy mapping
+    // RIGHT: byte 2 is 0xFF and byte 1 is 0x7F
+    if (report[2] == 0xFF && report[1] == 0x7F) { 
+        decoded_report |= MASK_JOY2_RIGHT; 
     }
-    // Up is when byte 1 is close to 0x00
-    if (report[1] < 0x40) { 
+    // UP: byte 1 is 0x00 and byte 2 is 0x7F
+    if (report[1] == 0x00 && report[2] == 0x7F) { 
         decoded_report |= MASK_JOY2_UP; 
     }
-    // Down is when byte 1 is close to 0xFF
-    if (report[1] > 0xB0) { 
+    // DOWN: byte 1 is 0xFF and byte 2 is 0x7F
+    if (report[1] == 0xFF && report[2] == 0x7F) { 
         decoded_report |= MASK_JOY2_DOWN; 
     }
 
-    // A Button (check for 0x2F or 0x1F in byte 6)
-    if ((report[6] & 0x20) || (report[6] & 0x10)) { 
+    // A button -> maps to MASK_KEY_USER3 (byte 6 is 0x2F)
+    if (report[6] == 0x2F) { 
         decoded_report |= MASK_KEY_USER3; 
     }
 
-    // B Button (check for 0x4F or 0x8F in byte 6)
-    if ((report[6] & 0x40) || (report[6] & 0x80)) { 
+    // B button -> maps to MASK_JOY2_BTN (byte 6 is 0x4F or 0x8F)
+    if ((report[6] == 0x4F) || (report[6] == 0x8F)) { 
         decoded_report |= MASK_JOY2_BTN; 
     }
 
-    // Select Button (byte 7, bit 0x10)
-    if (report[7] & 0x10) { 
+    // X button (debugging) (byte 6 is 0x1F)
+    if (report[6] == 0x1F) {
+        printf("X button pressed\n");
+    }
+
+    // Y button (debugging) (byte 6 is 0x8F)
+    if (report[6] == 0x8F) {
+        printf("Y button pressed\n");
+    }
+
+    // Start button -> maps to MASK_KEY_USER2 (byte 7 is 0x20)
+    if (report[7] == 0x20) { 
+        decoded_report |= MASK_KEY_USER2; 
+    }
+
+    // Select button -> maps to MASK_KEY_USER1 (byte 7 is 0x10)
+    if (report[7] == 0x10) { 
         decoded_report |= MASK_KEY_USER1; 
     }
 
-    // Start Button (byte 7, bit 0x20)
-    if (report[7] & 0x20) { 
-        decoded_report |= MASK_KEY_USER2; 
-    }
+    // Additional debug for button mappings
+    printf("Decoded report: %04x\n", decoded_report);
 
     // Send the decoded gamepad state
     kbd_signal_raw_gamepad(decoded_report);


### PR DESCRIPTION
add [usb gamepad](https://www.adafruit.com/product/6285) support to the gameboy pico2 emulator.

usb hid report:

default input (no buttons pressed): 00 7F 7F 00 80 80 0F 00 00
a: 00 7F 7F 00 80 80 2F 00 00
b: 00 7F 7F 00 80 80 4F 00 00
x: 00 7F 7F 00 80 80 1F 00 00
y: 00 7F 7F 00 80 80 8F 00 00
up: 00 7F 00 00 80 80 0F 00 00
down: 00 7F FF 00 80 80 0F 00 00
left: 00 00 7F 00 80 80 0F 00 00
right: 00 FF 7F 00 80 80 0F 00 00
start: 00 7F 7F 00 80 80 0F 20 00
select: 00 7F 7F 00 80 80 0F 10 00
r: 00 7F 7F 00 80 80 0F 02 00
l: 00 7F 7F 00 80 80 0F 01 00

first index seems to be ignored, so the 2nd [1] index is actually [0]